### PR TITLE
Check plugin version on activation of plugin

### DIFF
--- a/gis4wrf/core/__init__.py
+++ b/gis4wrf/core/__init__.py
@@ -6,6 +6,7 @@ from gis4wrf.core.downloaders.datasets import *
 from gis4wrf.core.downloaders.dist import *
 from gis4wrf.core.downloaders.geo import *
 from gis4wrf.core.downloaders.met import *
+from gis4wrf.core.downloaders.plugin_version import *
 from gis4wrf.core.readers.geogrid_tbl import *
 from gis4wrf.core.readers.grib_metadata import *
 from gis4wrf.core.readers.namelist import *

--- a/gis4wrf/core/downloaders/plugin_version.py
+++ b/gis4wrf/core/downloaders/plugin_version.py
@@ -1,0 +1,33 @@
+import io
+from pathlib import Path
+import xml.etree.ElementTree as ET
+import configparser
+from distutils.version import StrictVersion
+import requests
+
+from gis4wrf.core.util import export
+
+QGIS_PLUGINS_REPO_URL = 'https://plugins.qgis.org/plugins/plugins.xml?qgis=3.0.0'
+METADATA_PATH = Path(__file__).parents[2] / 'metadata.txt'
+
+@export
+def get_latest_gis4wrf_version() -> str:
+    response = requests.get(QGIS_PLUGINS_REPO_URL)
+    response.raise_for_status()
+    tree = ET.parse(io.BytesIO(response.content))
+    version_elements = tree.findall("./pyqgis_plugin[@name='GIS4WRF']/version")
+    if not version_elements:
+        raise RuntimeError('No version found')
+    versions = [i.text for i in version_elements]
+    latest_version = sorted(versions, key=StrictVersion)[-1]
+    return latest_version
+
+@export
+def get_installed_gis4wrf_version() -> str:
+    config = configparser.ConfigParser()
+    config.read(str(METADATA_PATH))
+    return config['general']['version']
+
+@export
+def is_newer_version(a: str, b: str) -> bool:
+    return StrictVersion(a) > StrictVersion(b)

--- a/gis4wrf/plugin/plugin.py
+++ b/gis4wrf/plugin/plugin.py
@@ -98,16 +98,19 @@ class QGISPlugin():
         webbrowser.open('https://github.com/GIS4WRF/gis4wrf/issues')
 
     def check_version(self) -> None:
+        def get_latest_delayed() -> str:
+            # When QGIS is started, display messages after QGIS 
+            # is fully loaded by waiting for 2 mins as plugins
+            # are activated whilst QGIS is loading.
+            time.sleep(120)
+            return get_latest_gis4wrf_version()
+
         def on_succeeded(latest: str) -> None:
             installed = get_installed_gis4wrf_version()
             if is_newer_version(latest, installed):
                 QMessageBox.information(self.iface.mainWindow(), PLUGIN_NAME,
                    'Your ' + PLUGIN_NAME + ' version is outdated, please update.\n' + \
                    'Installed: ' + installed + ', Latest: ' + latest, QMessageBox.Ok)
-
-        def get_latest_delayed() -> str:
-            time.sleep(120)
-            return get_latest_gis4wrf_version()
         
         thread = TaskThread(get_latest_delayed)
         thread.succeeded.connect(on_succeeded)

--- a/gis4wrf/plugin/plugin.py
+++ b/gis4wrf/plugin/plugin.py
@@ -3,24 +3,30 @@
 
 from typing import List, Callable
 import webbrowser
+import time
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QFileDialog
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QAction, QWidget
 from qgis.gui import QgisInterface
 
+from gis4wrf.core import (
+    get_latest_gis4wrf_version, get_installed_gis4wrf_version, is_newer_version)
 
 # Initialize Qt resources from auto-generated file resources.py
 import gis4wrf.plugin.resources
+
+from gis4wrf.plugin.ui.helpers import TaskThread
 
 from gis4wrf.plugin.ui.options import OptionsFactory
 from gis4wrf.plugin.ui.dock import MainDock
 from gis4wrf.plugin.ui.dialog_about import AboutDialog
 
 from gis4wrf.plugin.geo import add_default_basemap, load_wps_binary_layer
-from gis4wrf.plugin.constants import ( PLUGIN_NAME, GIS4WRF_LOGO_PATH, ADD_WRF_NETCDF_LAYER_ICON_PATH, 
-ADD_BINARY_LAYER_ICON_PATH, ABOUT_ICON_PATH, BUG_ICON_PATH)
+from gis4wrf.plugin.constants import (
+    PLUGIN_NAME, GIS4WRF_LOGO_PATH, ADD_WRF_NETCDF_LAYER_ICON_PATH, 
+    ADD_BINARY_LAYER_ICON_PATH, ABOUT_ICON_PATH, BUG_ICON_PATH)
 
 
 class QGISPlugin():
@@ -47,6 +53,8 @@ class QGISPlugin():
 
         self.options_factory = OptionsFactory()
         self.iface.registerOptionsWidgetFactory(self.options_factory)
+
+        self.check_version()
 
     def unload(self) -> None:
         """Removes the plugin menu item and icon from QGIS GUI.
@@ -88,6 +96,22 @@ class QGISPlugin():
 
     def report_bug(self) -> None:
         webbrowser.open('https://github.com/GIS4WRF/gis4wrf/issues')
+
+    def check_version(self) -> None:
+        def on_succeeded(latest: str) -> None:
+            installed = get_installed_gis4wrf_version()
+            if is_newer_version(latest, installed):
+                QMessageBox.information(self.iface.mainWindow(), PLUGIN_NAME,
+                   'Your ' + PLUGIN_NAME + ' version is outdated, please update.\n' + \
+                   'Installed: ' + installed + ', Latest: ' + latest, QMessageBox.Ok)
+
+        def get_latest_delayed() -> str:
+            time.sleep(120)
+            return get_latest_gis4wrf_version()
+        
+        thread = TaskThread(get_latest_delayed)
+        thread.succeeded.connect(on_succeeded)
+        thread.start()
 
     def add_action(self, icon_path: str, text: str, callback: Callable,
                    enabled_flag: bool=True, add_to_menu: bool=True,


### PR DESCRIPTION
When we release a new version on the QGIS repository we want to notify the user that a new version is available.  This enhancement  is used to check that the GIS4WRF version installed on the system is the latest, else we prompt the user with a message asking to update to the latest version. 