### PR TITLE
Allow to create/open projects without a WPS/WRF installation set

### DIFF
--- a/gis4wrf/core/project.py
+++ b/gis4wrf/core/project.py
@@ -96,6 +96,8 @@ class Project(object):
             (wrf_namelist_path, self.wrf_namelist_path)
         ]
         for src_path, dst_path in files:
+            if not src_path or not os.path.exists(src_path):
+                continue
             if not os.path.exists(dst_path):
                 shutil.copyfile(src_path, dst_path)
 
@@ -221,7 +223,9 @@ class Project(object):
 
     def fill_domains(self):
         ''' Updated computed fields in each domain object like cell size. '''
-        domains = self.data['domains']
+        domains = self.data.get('domains')
+        if domains is None:
+            raise RuntimeError('Domains not configured yet')
 
         innermost_domain = domains[0]
         outermost_domain = domains[-1]

--- a/gis4wrf/plugin/broadcast.py
+++ b/gis4wrf/plugin/broadcast.py
@@ -6,5 +6,7 @@ from PyQt5.QtCore import QObject, pyqtSignal
 class BroadcastSignals(QObject):
     geo_datasets_updated = pyqtSignal()
     met_datasets_updated = pyqtSignal()
+    options_updated = pyqtSignal()
+    project_updated = pyqtSignal()
 
 Broadcast = BroadcastSignals()

--- a/gis4wrf/plugin/options.py
+++ b/gis4wrf/plugin/options.py
@@ -8,6 +8,7 @@ import platform
 from qgis.core import QgsSettings
 
 from gis4wrf.core.util import export
+from gis4wrf.plugin.broadcast import Broadcast
 
 WORKING_DIR_DEFAULT_NAME = 'gis4wrf'
 
@@ -67,6 +68,7 @@ class Options(object):
         settings.setValue(Keys.RDA_USERNAME, self._rda_username)
         settings.setValue(Keys.RDA_PASSWORD, self._rda_password)
         self.after_load_save()
+        Broadcast.options_updated.emit()
 
     def after_load_save(self) -> None:
         for path in [self.working_dir, self.datasets_dir, self.geog_dir, self.projects_dir, self.distributions_dir]:

--- a/gis4wrf/plugin/ui/tab_simulation.py
+++ b/gis4wrf/plugin/ui/tab_simulation.py
@@ -66,7 +66,7 @@ class SimulationTab(QTabWidget):
         if project.path:
             if not self.options.wps_dir or not self.options.wrf_dir:
                 msg_bar = self.iface.messageBar() # type: QgsMessageBar
-                msg_bar.pushWarning(PLUGIN_NAME, 'WPS/WRF not found, functionality will be reduced.')
+                msg_bar.pushWarning(PLUGIN_NAME, 'PATH to WPS/WRF not set, functionality will be reduced. You can set PATH under Settings > Options... > GIS4WRF')
             self.update_project()
         self.general_tab.project = project
         self.domain_tab.project = project

--- a/gis4wrf/plugin/ui/tab_simulation.py
+++ b/gis4wrf/plugin/ui/tab_simulation.py
@@ -66,7 +66,7 @@ class SimulationTab(QTabWidget):
         if project.path:
             if not self.options.wps_dir or not self.options.wrf_dir:
                 msg_bar = self.iface.messageBar() # type: QgsMessageBar
-                msg_bar.pushWarning(PLUGIN_NAME, 'PATH to WPS/WRF not set, functionality will be reduced. You can set PATH under Settings > Options... > GIS4WRF')
+                msg_bar.pushWarning(PLUGIN_NAME, 'PATH to WPS/WRF not set, functionality will be reduced. You can set the PATH under Settings > Options... > GIS4WRF')
             self.update_project()
         self.general_tab.project = project
         self.domain_tab.project = project

--- a/gis4wrf/plugin/ui/widget_datasets.py
+++ b/gis4wrf/plugin/ui/widget_datasets.py
@@ -25,7 +25,7 @@ from gis4wrf.plugin.options import get_options
 from gis4wrf.plugin.geo import load_wps_binary_layer
 from gis4wrf.plugin.ui.helpers import add_grid_lineedit, add_grid_combobox, clear_layout, create_lineedit, StringValidator
 from gis4wrf.plugin.constants import PLUGIN_NAME
-from .broadcast import Broadcast
+from gis4wrf.plugin.broadcast import Broadcast
 
 class DatasetsWidget(QWidget):
     tab_active = pyqtSignal()
@@ -53,6 +53,7 @@ class DatasetsWidget(QWidget):
 
         Broadcast.geo_datasets_updated.connect(self.populate_geog_data_tree)
         Broadcast.met_datasets_updated.connect(self.populate_met_data_tree)
+        Broadcast.project_updated.connect(self.populate_geog_data_tree)
 
     @property
     def project(self) -> Project:
@@ -249,8 +250,10 @@ class DatasetsWidget(QWidget):
         tree = self.tree_geog_data
         tree.clear()
 
-        # FIXME guard if incorrect WPS path
-        tbl = self.geogrid_tbl = self.project.read_geogrid_tbl()
+        try:
+            tbl = self.geogrid_tbl = self.project.read_geogrid_tbl()
+        except FileNotFoundError:
+            return
         if tbl is None:
             return
         add_derived_metadata_to_geogrid_tbl(tbl, self.options.geog_dir)

--- a/gis4wrf/plugin/ui/widget_geo.py
+++ b/gis4wrf/plugin/ui/widget_geo.py
@@ -12,9 +12,9 @@ from gis4wrf.core import (
     dd_to_dms, formatted_dd_to_dms
 )
 from gis4wrf.plugin.options import get_options
+from gis4wrf.plugin.broadcast import Broadcast
 from gis4wrf.plugin.ui.helpers import reraise, MessageBar
 from gis4wrf.plugin.ui.thread import TaskThread
-from gis4wrf.plugin.ui.broadcast import Broadcast
 
 class GeoToolsDownloadManager(QWidget):
     def __init__(self, iface) -> None:

--- a/gis4wrf/plugin/ui/widget_met.py
+++ b/gis4wrf/plugin/ui/widget_met.py
@@ -16,9 +16,9 @@ from gis4wrf.core import (
     CRS)
 from gis4wrf.plugin.options import get_options
 from gis4wrf.plugin.geo import rect_to_bbox
+from gis4wrf.plugin.broadcast import Broadcast
 from gis4wrf.plugin.ui.helpers import add_grid_lineedit, MessageBar, reraise
 from gis4wrf.plugin.ui.thread import TaskThread
-from gis4wrf.plugin.ui.broadcast import Broadcast
 
 
 DECIMALS = 50

--- a/gis4wrf/plugin/ui/widget_run.py
+++ b/gis4wrf/plugin/ui/widget_run.py
@@ -96,9 +96,13 @@ class RunWidget(QWidget):
         self._project = val
 
     def prepare_wps_run(self) -> None:
+        if not self.options.wps_dir:
+            raise RuntimeError('WPS is not available!')
         self.project.prepare_wps_run(self.options.wps_dir)
 
     def prepare_wrf_run(self) -> None:
+        if not self.options.wrf_dir:
+            raise RuntimeError('WRF is not available!')
         self.project.prepare_wrf_run(self.options.wrf_dir)
 
     def on_open_namelist_wps_clicked(self) -> None:


### PR DESCRIPTION
This fixes #18.

- When opening/creating a project, the message "WPS/WRF not found, functionality will be reduced." appears in the message bar when WPS or WRF paths are not set. Clicking on the various "Run" buttons that depend on WPS/WRF now leads to an error message (plain exception currently).
- If a project was created without WPS set, then the geo datasets selector is empty, but will be populated as soon as WPS is configured in the options.

Note that I didn't bother surfacing the "Run" button errors as proper message bar messages but rather plain exceptions. Since pressing those buttons without WRF/WPS is a nonsense thing to do anyway it should be fine for now. At some point we can think about a bigger strategy on error handling, including custom exception classes and more consistency.