### PR TITLE
Allow to use custom met datasets

### DIFF
--- a/gis4wrf/plugin/options.py
+++ b/gis4wrf/plugin/options.py
@@ -138,13 +138,6 @@ class Options(object):
         return os.path.join(self.wps_dir, 'ungrib', 'Variable_Tables')
 
     @property
-    def ungrib_vtable_filenames(self) -> Optional[List[str]]:
-        if not self.wps_dir:
-            return None
-        vtable_dir = self.ungrib_vtable_dir
-        return sorted(filename for filename in os.listdir(vtable_dir) if filename.startswith('Vtable.'))
-
-    @property
     def metgrid_exe(self) -> Optional[str]:
         if not self.wps_dir:
             return None

--- a/gis4wrf/plugin/options.py
+++ b/gis4wrf/plugin/options.py
@@ -1,7 +1,7 @@
 # GIS4WRF (https://doi.org/10.5281/zenodo.1288569)
 # Copyright (c) 2018 D. Meyer and M. Riechert. Licensed under MIT.
 
-from typing import Optional
+from typing import Optional, List
 import os
 import platform
 
@@ -130,6 +130,19 @@ class Options(object):
         if not self.wps_dir:
             return None
         return os.path.join(self.wps_dir, 'ungrib.exe')
+
+    @property
+    def ungrib_vtable_dir(self) -> Optional[str]:
+        if not self.wps_dir:
+            return None
+        return os.path.join(self.wps_dir, 'ungrib', 'Variable_Tables')
+
+    @property
+    def ungrib_vtable_filenames(self) -> Optional[List[str]]:
+        if not self.wps_dir:
+            return None
+        vtable_dir = self.ungrib_vtable_dir
+        return sorted(filename for filename in os.listdir(vtable_dir) if filename.startswith('Vtable.'))
 
     @property
     def metgrid_exe(self) -> Optional[str]:

--- a/gis4wrf/plugin/plugin.py
+++ b/gis4wrf/plugin/plugin.py
@@ -76,8 +76,7 @@ class QGISPlugin():
         add_default_basemap()
 
     def show_about(self) -> None:
-        self.dlg = AboutDialog()
-        self.dlg.show()
+        AboutDialog().exec_()
 
     def add_wrf_layer(self) -> None:
         path, _ = QFileDialog.getOpenFileName(caption='Open WRF NetCDF File')

--- a/gis4wrf/plugin/ui/dialog_custom_met_dataset.py
+++ b/gis4wrf/plugin/ui/dialog_custom_met_dataset.py
@@ -24,6 +24,7 @@ class CustomMetDatasetDialog(QDialog):
     def __init__(self, vtable_dir: str, spec: Optional[dict]=None) -> None:
         super().__init__()
 
+        self.vtable_dir = vtable_dir
         self.paths = set() # type: Set[Path]
 
         geom = QGuiApplication.primaryScreen().geometry()
@@ -128,7 +129,7 @@ class CustomMetDatasetDialog(QDialog):
         if not self.vtable_path:
             error('No VTable file selected.')
             return
-        if not os.path.exists(self.vtable_path):
+        if not os.path.exists(os.path.join(self.vtable_dir, self.vtable_path)):
             error('VTable file does not exist.')
             return
         self.accept()

--- a/gis4wrf/plugin/ui/dialog_custom_met_dataset.py
+++ b/gis4wrf/plugin/ui/dialog_custom_met_dataset.py
@@ -1,0 +1,175 @@
+# GIS4WRF (https://doi.org/10.5281/zenodo.1288569)
+# Copyright (c) 2018 D. Meyer and M. Riechert. Licensed under MIT.
+
+from typing import List, Set, Optional
+import os
+from pathlib import Path
+from datetime import datetime
+
+from PyQt5.QtCore import Qt, QDate, QTime, QDateTime
+
+from PyQt5.QtGui import (
+    QIntValidator, QGuiApplication
+)
+from PyQt5.QtWidgets import (
+    QPushButton, QVBoxLayout, QDialog, QGridLayout,
+    QHBoxLayout, QFileDialog, QDialogButtonBox, QMessageBox, QListWidget, QListWidgetItem,
+    QAbstractItemView, QDateTimeEdit, QLabel
+)
+
+from gis4wrf.plugin.ui.helpers import add_grid_lineedit, add_grid_combobox, add_grid_labeled_widget
+
+
+class CustomMetDatasetDialog(QDialog):
+    def __init__(self, vtable_filenames: List[str], spec: Optional[dict]=None) -> None:
+        super().__init__()
+
+        self.paths = set() # type: Set[Path]
+
+        geom = QGuiApplication.primaryScreen().geometry()
+        w, h = geom.width(), geom.height()
+        self.setWindowTitle("Custom Meteorological Dataset")
+        self.setMinimumSize(w * 0.25, h * 0.35)
+
+        layout = QVBoxLayout()
+
+        # button to open folder/files dialog
+        hbox = QHBoxLayout()
+        layout.addLayout(hbox)
+        add_folder_btn = QPushButton('Add folder')
+        add_files_btn = QPushButton('Add files')
+        remove_selected_btn = QPushButton('Remove selected')
+        hbox.addWidget(add_folder_btn)
+        hbox.addWidget(add_files_btn)
+        hbox.addWidget(remove_selected_btn)
+        add_folder_btn.clicked.connect(self.on_add_folder_btn_clicked)
+        add_files_btn.clicked.connect(self.on_add_files_btn_clicked)
+        remove_selected_btn.clicked.connect(self.on_remove_selected_btn_clicked)
+
+        # show added files in a list
+        self.paths_list = QListWidget()
+        self.paths_list.setSelectionMode(QAbstractItemView.ContiguousSelection)
+        layout.addWidget(self.paths_list)
+
+        grid = QGridLayout()
+        layout.addLayout(grid)
+
+        # date/time start/end
+        self.start_date_input = QDateTimeEdit()
+        self.start_date_input.setCalendarPopup(True)
+
+        self.end_date_input = QDateTimeEdit()
+        self.end_date_input.setCalendarPopup(True)
+        
+        add_grid_labeled_widget(grid, 0, 'Start Date/Time', self.start_date_input)
+        add_grid_labeled_widget(grid, 1, 'End Date/Time', self.end_date_input)
+
+        # interval in seconds
+        interval_validator = QIntValidator()
+        interval_validator.setBottom(1)
+        self.interval_input = add_grid_lineedit(grid, 2, 'Interval in seconds', interval_validator, required=True)   
+
+        # vtable dropdown
+        self.vtable_selector = add_grid_combobox(grid, 3, 'VTable')
+        for filename in vtable_filenames:
+            self.vtable_selector.addItem(filename)
+
+        btn_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        btn_box.accepted.connect(self.on_ok_clicked)
+        btn_box.rejected.connect(self.reject)
+        layout.addWidget(btn_box)
+        
+        self.setLayout(layout)
+
+        if spec:
+            self.paths = set(map(Path, spec['paths']))
+            self.base_folder = spec['base_folder']
+            self.update_file_list()
+
+            start_date, end_date = spec['time_range']
+            for date_input, date in [(self.start_date_input, start_date), (self.end_date_input, end_date)]:
+                date_input.setDateTime(QDateTime(QDate(date.year, date.month, date.day), QTime(date.hour, date.minute)))
+
+            self.interval_input.set_value(spec['interval_seconds'])
+
+            self.vtable_selector.setCurrentText(spec['vtable'])
+
+    @property
+    def start_date(self) -> datetime:
+        return self.start_date_input.dateTime().toPyDateTime()
+
+    @property
+    def end_date(self) -> datetime:
+        return self.end_date_input.dateTime().toPyDateTime()
+
+    @property
+    def interval_seconds(self) -> int:
+        return self.interval_input.value()
+
+    @property
+    def vtable(self) -> str:
+        return self.vtable_selector.currentText()
+
+    def on_ok_clicked(self) -> None:
+        def error(msg: str) -> None:
+            QMessageBox.critical(self, 'Invalid input', msg)
+        if not self.paths:
+            error('No GRIB files were added.')
+            return
+        if not self.interval_input.is_valid():
+            error('Interval must be an integer above 0.')
+            return
+        if self.start_date == self.end_date:
+            error('Start date cannot be the same as end date.')
+            return
+        if self.start_date > self.end_date:
+            error('Start date cannot be after the end date.')
+            return
+        self.accept()
+
+    def on_add_folder_btn_clicked(self) -> None:
+        folder = QFileDialog.getExistingDirectory(caption='Select folder')
+        if not folder:
+            return
+        paths = [] # type: List[Path]
+        for root, _, filenames in os.walk(folder):
+            paths.extend(Path(root) / filename for filename in filenames)
+        self.update_paths(self.paths.union(paths))
+        self.update_file_list()
+    
+    def on_add_files_btn_clicked(self) -> None:
+        paths, _ = QFileDialog.getOpenFileNames(caption='Select files')
+        if not paths:
+            return
+
+        self.update_paths(self.paths.union(map(Path, paths)))
+        self.update_file_list()
+
+    def on_remove_selected_btn_clicked(self) -> None:
+        paths = [item.data(Qt.UserRole) for item in self.paths_list.selectedItems()]
+        self.update_paths(self.paths.difference(paths))
+        self.update_file_list()
+
+    def update_paths(self, paths: Set[Path]) -> None:
+        if len(paths) == 1:
+            # special case as os.path.commonpath() would return '.'
+            base_folder = os.path.dirname(list(paths)[0])
+        elif paths:
+            try:
+                base_folder = os.path.commonpath(paths)
+            except ValueError:
+                QMessageBox.critical(self, 'Invalid input', 'All files must be located on the same drive.')
+                return
+        else:
+            base_folder = None
+
+        self.base_folder = base_folder
+        self.paths = paths
+
+    def update_file_list(self) -> None:
+        self.paths_list.clear()
+        for path in sorted(self.paths):
+            item = QListWidgetItem(str(path))
+            item.setData(Qt.UserRole, path)
+            self.paths_list.addItem(item)
+

--- a/gis4wrf/plugin/ui/helpers.py
+++ b/gis4wrf/plugin/ui/helpers.py
@@ -143,9 +143,8 @@ def add_grid_lineedit(grid: QGridLayout, row: int, label_name: str, validator: O
     """Helper to return a 'validator-ready' grid layout
     composed of a name label, line edit and optional unit.
     """
-    grid.addWidget(QLabel(label_name + ':'), row, 0)
     lineedit = create_lineedit(validator, required)
-    grid.addWidget(lineedit, row, 1)
+    add_grid_labeled_widget(grid, row, label_name, lineedit)
     if unit:
         grid.addWidget(QLabel(unit), row, 2)
     return lineedit
@@ -154,10 +153,13 @@ def add_grid_combobox(grid: QGridLayout, row: int, label_name: str) -> QComboBox
     """Helper to return a 'validator-ready' grid layout
     composed of a name label, line edit and optional unit.
     """
-    grid.addWidget(QLabel(label_name + ':'), row, 0)
     combo = QComboBox()
-    grid.addWidget(combo, row, 1)
+    add_grid_labeled_widget(grid, row, label_name, combo)
     return combo
+
+def add_grid_labeled_widget(grid: QGridLayout, row: int, label_name: str, widget: QWidget) -> None:
+    grid.addWidget(QLabel(label_name + ':'), row, 0)
+    grid.addWidget(widget, row, 1)
 
 def create_two_radio_group_box(radio1_name: str, radio2_name: str,
                                gbox_name: str) -> QGroupBox:

--- a/gis4wrf/plugin/ui/widget_datasets.py
+++ b/gis4wrf/plugin/ui/widget_datasets.py
@@ -3,6 +3,7 @@
 
 from operator import xor
 import os
+from pathlib import Path
 import re
 
 from PyQt5.QtCore import Qt, pyqtSignal
@@ -541,14 +542,19 @@ class DatasetsWidget(QWidget):
             # met data not configured yet
             spec = None
 
-        dialog = CustomMetDatasetDialog(self.options.ungrib_vtable_filenames, spec)
+        dialog = CustomMetDatasetDialog(self.options.ungrib_vtable_dir, spec)
         if not dialog.exec_():
             return
+
+        vtable_path = dialog.vtable_path
+        # only store absolute path if not a standard WPS vtable
+        if Path(vtable_path).parent == Path(self.options.ungrib_vtable_dir):
+            vtable_path = Path(vtable_path).name
 
         self.project.met_dataset_spec = {
             'paths': dialog.paths,
             'base_folder': dialog.base_folder,
-            'vtable': dialog.vtable,
+            'vtable': vtable_path,
             'time_range': [dialog.start_date, dialog.end_date],
             'interval_seconds': dialog.interval_seconds
         }


### PR DESCRIPTION
This implements #23.

There's a new button in the met dataset selector. Also, "Current configuration" shows a different text if a custom dataset is used:

![grafik](https://user-images.githubusercontent.com/530988/43045574-e5a0a298-8db2-11e8-904d-398bf404fd0b.png)

Clicking on the button opens a dialog for defining the custom dataset:

![grafik](https://user-images.githubusercontent.com/530988/43045537-3874f8ee-8db2-11e8-991f-8c3db6f1d131.png)

Adding a folder recursively adds all files in it. Unwanted files can be removed again with "Remove selected".

Note that the custom dataset information is stored in the project but is not added to the "Available datasets" list from the first screenshot. This was simpler to handle and shouldn't present any limitation.