### PR TITLE
Add support for importing existing namelist.wps (closes #27)

### DIFF
--- a/gis4wrf/core/transforms/wps_namelist_to_project.py
+++ b/gis4wrf/core/transforms/wps_namelist_to_project.py
@@ -8,27 +8,29 @@ from gis4wrf.core.project import Project
 @export
 def convert_wps_nml_to_project(nml: dict, existing_project: Project) -> Project:
     data = existing_project.data.copy()
-    data['domains'] = convert_nml_to_gis4wrf_domains(nml)
+    data['domains'] = convert_nml_to_project_domains(nml)
     project = Project(data, existing_project.path)
     return project
 
-def convert_nml_to_gis4wrf_domains(nml: dict) -> List[dict]:
+def convert_nml_to_project_domains(nml: dict) -> List[dict]:
+    max_dom = nml['share']['max_dom'] # type: int
+
+    nml = nml['geogrid']
+    map_proj = nml['map_proj'] # type: str
     parent_id = nml['parent_id'] # type: List[int]
     parent_grid_ratio = nml['parent_grid_ratio'] # type: List[int]
     i_parent_start = nml['i_parent_start'] # type: List[int]
     j_parent_start = nml['j_parent_start'] # type: List[int]
     e_we = nml['e_we'] # type: List[int]
     e_sn = nml['e_sn'] # type: List[int]
-    map_proj = nml['map_proj'] # type: str
     dx = [nml['dx']] # type: List[float]
     dy = [nml['dy']] # type: List[float]
     ref_lon = [nml['ref_lon']] # type: List[float]
     ref_lat = [nml['ref_lat']] # type: List[float]
-    max_dom = nml['max_dom'] # type: int
 
     # Check that there are no domains with 2 nests on the same level
     if parent_id != [1] + list(range(1, max_dom)):
-        raise RuntimeError(f'We only support 1 nested domain per parent domain.')
+        raise RuntimeError('We only support 1 nested domain per parent domain.')
 
     # Check if projection is currently supported
     SUPPORTED_PROJ = ['lat-lon']

--- a/gis4wrf/core/transforms/wps_namelist_to_project.py
+++ b/gis4wrf/core/transforms/wps_namelist_to_project.py
@@ -1,10 +1,91 @@
 # GIS4WRF (https://doi.org/10.5281/zenodo.1288569)
 # Copyright (c) 2018 D. Meyer and M. Riechert. Licensed under MIT.
 
+from typing import List
 from gis4wrf.core.util import export
 from gis4wrf.core.project import Project
 
 @export
-def convert_wps_nml_to_project(nml: dict) -> Project:
-    # TODO implement
-    pass
+def convert_wps_nml_to_project(nml: dict, existing_project: Project) -> Project:
+    data = existing_project.data.copy()
+    data['domains'] = convert_nml_to_gis4wrf_domains(nml)
+    project = Project(data, existing_project.path)
+    return project
+
+def convert_nml_to_gis4wrf_domains(nml: dict) -> List[dict]:
+    parent_id = nml['parent_id'] # type: List[int]
+    parent_grid_ratio = nml['parent_grid_ratio'] # type: List[int]
+    i_parent_start = nml['i_parent_start'] # type: List[int]
+    j_parent_start = nml['j_parent_start'] # type: List[int]
+    e_we = nml['e_we'] # type: List[int]
+    e_sn = nml['e_sn'] # type: List[int]
+    map_proj = nml['map_proj'] # type: str
+    dx = [nml['dx']] # type: List[float]
+    dy = [nml['dy']] # type: List[float]
+    ref_lon = [nml['ref_lon']] # type: List[float]
+    ref_lat = [nml['ref_lat']] # type: List[float]
+    max_dom = nml['max_dom'] # type: int
+
+    # Check that there are no domains with 2 nests on the same level
+    if parent_id != [1] + list(range(1, max_dom)):
+        raise RuntimeError(f'We only support 1 nested domain per parent domain.')
+
+    # Check if projection is currently supported
+    SUPPORTED_PROJ = ['lat-lon']
+    if map_proj not in SUPPORTED_PROJ:
+        raise NotImplementedError(f'Map projection in namelist not currently supported. \n\
+                        Currently supported projections are {SUPPORTED_PROJ}.')
+
+    min_lon = [] # type: List[float]
+    min_lat = [] # type: List[float]
+    padding_left = [] # type: List[int]
+    padding_bottom = [] # type: List[int]
+    padding_right = [] # type: List[int]
+    padding_top = [] # type: List[int]
+
+    cols = [i - 1 for i in e_we]
+    rows = [i - 1 for i in e_sn]
+
+    for idx in range(max_dom - 1):
+        # Calculate horizontal grid spacing for inner domain
+        dx.append(dx[idx] / parent_grid_ratio[idx+1])
+        dy.append(dy[idx] / parent_grid_ratio[idx+1])
+
+        if idx == 0:
+            # Find the min coordinates for the outermost domain
+            min_lon.append(ref_lon[idx] - (dx[idx] * (cols[idx] / 2)))
+            min_lat.append(ref_lat[idx] - (dy[idx] * (rows[idx] / 2)))
+
+        # Find the min coordinates for the outer domain
+        min_lon.append(min_lon[idx] + (dx[idx] * (i_parent_start[idx+1] - 1)))
+        min_lat.append(min_lat[idx] + (dy[idx] * (j_parent_start[idx+1] - 1)))
+
+        # Find center coordinates for inner domain
+        ref_lon.append(min_lon[idx+1] + (dx[idx+1] * (cols[idx+1] / 2)))
+        ref_lat.append(min_lat[idx+1] + (dy[idx+1] * (rows[idx+1] / 2)))
+
+        padding_left.append(i_parent_start[idx+1] - 1)
+        padding_bottom.append(j_parent_start[idx+1] - 1)
+
+        padding_right.append(cols[idx] - padding_left[idx] - cols[idx+1] // parent_grid_ratio[idx+1])
+        padding_top.append(rows[idx] - padding_bottom[idx] - rows[idx+1] // parent_grid_ratio[idx+1])
+
+    first_domain = {
+        'map_proj': map_proj,
+        'cell_size': [dx[-1], dy[-1]],
+        'center_lonlat': [ref_lon[-1], ref_lat[-1]],
+        'domain_size': [cols[-1], rows[-1]],
+        'stand_lon': 0.0,
+    }
+
+    domains = [first_domain]
+    for i in range(max_dom - 1):
+        domains.append({
+            'parent_cell_size_ratio': parent_grid_ratio[::-1][:-1][i],
+            "padding_left": padding_left[::-1][i],
+            "padding_right": padding_right[::-1][i],
+            "padding_bottom": padding_bottom[::-1][i],
+            "padding_top": padding_top[::-1][i]
+        })
+
+    return domains

--- a/gis4wrf/plugin/broadcast.py
+++ b/gis4wrf/plugin/broadcast.py
@@ -3,10 +3,13 @@
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
+from gis4wrf.core import Project
+
 class BroadcastSignals(QObject):
     geo_datasets_updated = pyqtSignal()
     met_datasets_updated = pyqtSignal()
     options_updated = pyqtSignal()
     project_updated = pyqtSignal()
+    open_project_from_object = pyqtSignal(Project)
 
 Broadcast = BroadcastSignals()

--- a/gis4wrf/plugin/ui/tab_simulation.py
+++ b/gis4wrf/plugin/ui/tab_simulation.py
@@ -54,6 +54,7 @@ class SimulationTab(QTabWidget):
 
         self.currentChanged.connect(self.on_tab_changed)
         Broadcast.options_updated.connect(self.update_project)
+        Broadcast.open_project_from_object.connect(self.open_project_from_object)
 
     def open_data_tab(self):
         self.setCurrentIndex(2)
@@ -99,6 +100,15 @@ class SimulationTab(QTabWidget):
         self.project.save()
         self.set_project_in_tabs()
         self.enable_project_dependent_tabs()
+
+    def open_project_from_object(self, project: Project) -> None:
+        self.project = project
+        self.set_project_in_tabs()
+        if project.path:
+            self.enable_project_dependent_tabs()
+            self.project.save()
+        else:
+            self.disable_project_dependent_tabs()
 
     def on_open_project(self, path: str) -> None:
         self.project = Project.load(path)

--- a/gis4wrf/plugin/ui/widget_domains.py
+++ b/gis4wrf/plugin/ui/widget_domains.py
@@ -22,6 +22,7 @@ from gis4wrf.plugin.ui.helpers import (
     MyLineEdit, add_grid_lineedit, update_input_validation_style, create_lineedit,
     create_two_radio_group_box, WhiteScroll, RATIO_VALIDATOR, DIM_VALIDATOR
 )
+from gis4wrf.plugin.broadcast import Broadcast
 
 MAX_PARENTS = 22
 DECIMALS = 50
@@ -44,7 +45,7 @@ class DomainWidget(QWidget):
         # Import/Export
         ## Import from 'namelist.wps'
         import_from_namelist_button = QPushButton("Import from namelist")
-        import_from_namelist_button.setObjectName('import_from_namelist')
+        import_from_namelist_button.setObjectName('import_from_namelist_button')
 
         ## Export to namelist
         export_geogrid_namelist_button = QPushButton("Export to namelist")
@@ -276,13 +277,13 @@ class DomainWidget(QWidget):
         self.draw_bbox_and_grids(zoom_out=True)
 
     @pyqtSlot()
-    def on_import_from_namelist_button_clicked(self):
+    def on_import_from_namelist_button_clicked(self) -> None:
         file_path, _ = QFileDialog.getOpenFileName(caption='Open wps namelist')
         if not file_path:
             return
-        nml = read_namelist(file_path)
+        nml = read_namelist(file_path, schema_name='wps')
         project = convert_wps_nml_to_project(nml, self.project)
-        # TODO load new project
+        Broadcast.open_project_from_object.emit(project)
 
     @pyqtSlot()
     def on_export_geogrid_namelist_button_clicked(self):

--- a/gis4wrf/plugin/ui/widget_domains.py
+++ b/gis4wrf/plugin/ui/widget_domains.py
@@ -13,9 +13,10 @@ from PyQt5.QtWidgets import (
 from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsRectangle
 from qgis.gui import QgisInterface
 
-from gis4wrf.core import LonLat, Coordinate2D, CRS, Project
-from gis4wrf.core.writers.namelist import write_namelist
-from gis4wrf.core.transforms.project_to_wps_namelist import convert_project_to_wps_namelist
+from gis4wrf.core import (
+    LonLat, Coordinate2D, CRS, Project, read_namelist, write_namelist,
+    convert_wps_nml_to_project, convert_project_to_wps_namelist
+)
 from gis4wrf.plugin.geo import update_domain_outline_layers, update_domain_grid_layers, get_qgis_crs, rect_to_bbox
 from gis4wrf.plugin.ui.helpers import (
     MyLineEdit, add_grid_lineedit, update_input_validation_style, create_lineedit,
@@ -273,6 +274,15 @@ class DomainWidget(QWidget):
                     field.set_value(val)
         
         self.draw_bbox_and_grids(zoom_out=True)
+
+    @pyqtSlot()
+    def on_import_from_namelist_button_clicked(self):
+        file_path, _ = QFileDialog.getOpenFileName(caption='Open wps namelist')
+        if not file_path:
+            return
+        nml = read_namelist(file_path)
+        project = convert_wps_nml_to_project(nml, self.project)
+        # TODO load new project
 
     @pyqtSlot()
     def on_export_geogrid_namelist_button_clicked(self):


### PR DESCRIPTION
This PR solves #27. We adds support for importing existing namelist.wps into GIS4WRF using the `Import from namelist`  button under `Simulation` > `Domain`. Domains are automatically visualised. We currently support `lat-lon` and `lambert` projections.