### PR TITLE
Error if MPI is enabled but pre-built distribution without MPI support is used

### DIFF
--- a/gis4wrf/plugin/ui/helpers.py
+++ b/gis4wrf/plugin/ui/helpers.py
@@ -91,9 +91,12 @@ class MessageBar(object):
     def success(self, msg: str) -> None:
         self.msg_bar.pushSuccess(PLUGIN_NAME, msg)
 
+    def warning(self, msg: str) -> None:
+        self.msg_bar.pushWarning(PLUGIN_NAME, msg)
+
     def error(self, msg: str) -> None:
         self.msg_bar.pushCritical(PLUGIN_NAME, msg)
-
+    
 
 def update_input_validation_style(widget: MyLineEdit) -> None:
     """Updates the background color of a line edit.

--- a/gis4wrf/plugin/ui/options.py
+++ b/gis4wrf/plugin/ui/options.py
@@ -110,8 +110,8 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
         vbox.addLayout(hbox)
 
         hbox = QHBoxLayout()
-        download_wps = QPushButton('Download Pre-Compiled WPS Distribution...')
-        download_wrf = QPushButton('Download Pre-Compiled WRF Distribution...')
+        download_wps = QPushButton(f'Download Pre-Compiled WPS {WRF_WPS_DIST_VERSION} Distribution...')
+        download_wrf = QPushButton(f'Download Pre-Compiled WRF {WRF_WPS_DIST_VERSION} Distribution...')
         download_wps.clicked.connect(self.download_wps)
         download_wrf.clicked.connect(self.download_wrf)
         hbox.addWidget(download_wps)


### PR DESCRIPTION
The check is simplistic but should be good enough for our purposes. It checks if the executable path contains `-nompi` (which the plugin uses when downloading/extracting the serial distributions) and errors if MPI was enabled in the plugin. Note that running MPI-enabled WRF/WPS distributions without MPI enabled (without mpiexec) is normally harmless and just runs them serially, so this condition is not checked.

![grafik](https://user-images.githubusercontent.com/530988/45930344-dc5d6100-bf56-11e8-97b0-5ee788e841d8.png)

Also, to make it clearer, I changed the download buttons to include the WRF/WPS version: 
![grafik](https://user-images.githubusercontent.com/530988/45930385-71605a00-bf57-11e8-8d55-9576caabcbc3.png)

