### PR TITLE
Show progress during WRF/WPS distribution download

### DIFF
--- a/gis4wrf/core/downloaders/dist.py
+++ b/gis4wrf/core/downloaders/dist.py
@@ -1,6 +1,7 @@
 # GIS4WRF (https://doi.org/10.5281/zenodo.1288569)
 # Copyright (c) 2018 D. Meyer and M. Riechert. Licensed under MIT.
 
+from typing import Iterable, Tuple
 import os
 import shutil
 import tempfile
@@ -9,7 +10,7 @@ import platform
 from gis4wrf.core.util import export, remove_dir
 from gis4wrf.core.constants import WPS_DIST, WRF_DIST
 from gis4wrf.core.errors import UnsupportedError
-from .util import download_file
+from .util import download_file_with_progress
 
 @export
 def get_wrf_dist_url(mpi: bool) -> str:
@@ -39,14 +40,17 @@ def get_dist_url(dist: dict, mpi: bool) -> str:
     return url
 
 @export
-def download_and_extract_dist(url: str, folder: str) -> None:
+def download_and_extract_dist(url: str, folder: str) -> Iterable[Tuple[float,str]]:
     tmp_dir = tempfile.mkdtemp()
     tmp_path = os.path.join(tmp_dir, url.split('/')[-1])
     if os.path.exists(folder):
         remove_dir(folder)
     os.makedirs(folder)
     try:
-        download_file(url, tmp_path)       
+        for progress in download_file_with_progress(url, tmp_path):
+            yield progress * 0.95, 'downloading'
+        yield 0.95, 'extracting'
         shutil.unpack_archive(tmp_path, folder)
     finally:
         shutil.rmtree(tmp_dir)
+    yield 1.0, 'done'

--- a/gis4wrf/plugin/ui/helpers.py
+++ b/gis4wrf/plugin/ui/helpers.py
@@ -266,20 +266,28 @@ class IgnoreKeyPressesDialog(QDialog):
         # Overriding this method prevents this behaviour.
         pass
 
+# higher resolution than default (100)
+PROGRESS_BAR_MAX = 1000
+
 class WaitDialog(IgnoreKeyPressesDialog):
-    def __init__(self, parent, title):
+    def __init__(self, parent, title, progress=False) -> None:
         super().__init__(parent, Qt.WindowTitleHint)
         vbox = QVBoxLayout()
-        bar = QProgressBar()
-        bar.setRange(0, 0)
-        bar.setTextVisible(False)
-        vbox.addWidget(bar)
+        self.progress_bar = QProgressBar()
+        max_val = PROGRESS_BAR_MAX if progress else 0
+        self.progress_bar.setRange(0, max_val)
+        self.progress_bar.setTextVisible(False)
+        vbox.addWidget(self.progress_bar)
         self.setModal(True)
         self.setWindowTitle(title)
         self.setLayout(vbox)
         self.setMaximumHeight(0)
         self.setFixedWidth(parent.width() * 0.5)
         self.show()
+    
+    def update_progress(self, progress: float) -> None:
+        self.progress_bar.setValue(int(progress * PROGRESS_BAR_MAX))
+        self.progress_bar.repaint() # otherwise just updates in 1% steps
 
 def install_user_error_handler(iface: QgisInterface) -> None:
     # Lazy import to work around restriction explained at top of this file.

--- a/gis4wrf/plugin/ui/options.py
+++ b/gis4wrf/plugin/ui/options.py
@@ -210,10 +210,11 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
         if not self.confirm_dist_download(name, mpi, url):
             return
 
-        wait_dialog = WaitDialog(self, 'Downloading...')
+        wait_dialog = WaitDialog(self, 'Downloading...', progress=True)
                 
         folder = self.get_dist_download_folder(name, mpi)
-        thread = TaskThread(lambda: download_and_extract_dist(url, folder))
+        thread = TaskThread(lambda: download_and_extract_dist(url, folder), yields_progress=True)
+        thread.progress.connect(lambda progress, _: wait_dialog.update_progress(progress))
         thread.finished.connect(lambda: wait_dialog.accept())
         thread.succeeded.connect(lambda: on_success(folder))
         thread.failed.connect(reraise)


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/530988/45930594-0fedba80-bf5a-11e8-9f1c-aca77d95ea47.png)

Now we have progress bars everywhere! Well, except for running WRF, that might be fun...