### PR TITLE
Proactively enable MPI if available when user hasn't setup WRF/WPS distribution yet

### DIFF
--- a/gis4wrf/plugin/options.py
+++ b/gis4wrf/plugin/options.py
@@ -8,6 +8,7 @@ import multiprocessing
 
 from qgis.core import QgsSettings
 
+from gis4wrf.core import find_mpiexec
 from gis4wrf.core.util import export
 from gis4wrf.plugin.broadcast import Broadcast
 
@@ -61,6 +62,17 @@ class Options(object):
         self._rda_username = settings.value(Keys.RDA_USERNAME)
         self._rda_password = settings.value(Keys.RDA_PASSWORD)
 
+        # Proactively enable MPI if available and if no WRF/WPS distributions are set yet.
+        # This will lead more people to download the pre-built MPI-enabled distributions.
+        if not self._mpi_enabled and not self._wrf_dir and not self._wps_dir:
+            try:
+                find_mpiexec()
+            except:
+                pass
+            else:
+                self.mpi_enabled = True
+                self.save()
+
         self.after_load_save()
 
     def save(self) -> None:
@@ -86,7 +98,6 @@ class Options(object):
     @working_dir.setter
     def working_dir(self, path) -> None:
         self._working_dir = path
-        self.save()
 
     @property
     def mpi_enabled(self) -> bool:
@@ -113,7 +124,6 @@ class Options(object):
         if not path:
             path = None
         self._wrf_dir = path
-        self.save()
 
     @property
     def wps_dir(self) -> Optional[str]:
@@ -124,7 +134,6 @@ class Options(object):
         if not path:
             path = None
         self._wps_dir = path
-        self.save()
 
     @property
     def geogrid_exe(self) -> Optional[str]:
@@ -191,7 +200,6 @@ class Options(object):
     @rda_username.setter
     def rda_username(self, username: str) -> None:
         self._rda_username = username
-        self.save()
 
     @property
     def rda_password(self) -> str:
@@ -200,7 +208,6 @@ class Options(object):
     @rda_password.setter
     def rda_password(self, password: str) -> None:
         self._rda_password = password
-        self.save()
 
     @property
     def projects_dir(self) -> str:

--- a/gis4wrf/plugin/ui/options.py
+++ b/gis4wrf/plugin/ui/options.py
@@ -67,6 +67,7 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
         self.options.wps_dir = self.wps_dir.text()
         self.options.rda_username = self.rda_username.text()
         self.options.rda_password = self.rda_password.text()
+        self.options.save()
 
     def create_distribution_box(self) -> Tuple[QCheckBox, QSpinBox, QLineEdit, QLineEdit, QGroupBox]:
         gbox = QGroupBox('WPS/WRF Integration')
@@ -74,13 +75,12 @@ class ConfigOptionsPage(QgsOptionsPageWidget):
         gbox.setLayout(vbox)
 
         text = """<html>GIS4WRF allows you to run WPS and WRF on your local system.
-                  We offer pre-compiled WPS/WRF binary-distributions for Windows, macOS and Linux 
+                  We offer pre-compiled WPS/WRF binary distributions for Windows, macOS and Linux 
                   using <a href="https://github.com/WRF-CMake/WRF#readme">WPS-CMake and WRF-CMake</a> (experimental). 
                   You can download the pre-compiled WPS/WRF binaries by clicking on the buttons below. 
                   Note that pre-compiled distributions are only available with basic nesting support.
-                  Alternatively, If you have an existing compilation of WPS and/or WRF, simply point to their respective
-                  folders below. If you compiled with <code>dmpar</code> make sure
-                  to tick the "MPI" checkbox. 
+                  Alternatively, if you have an existing compilation of WPS and/or WRF, simply point to their respective
+                  folders below. If you compiled with <code>dmpar</code> make sure to tick the "MPI" checkbox. 
                   </html>"""
         label = QLabel(text)
         label.setWordWrap(True)


### PR DESCRIPTION
This implements #82. The original suggestion mentioned Linux and macOS only, but I see no issue following the same logic on Windows, so this PR does it for all systems.

The PR also contains a little refactoring around calling `.save()` and some typo fixes.