### PR TITLE
0.13.1 HotFix Release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+0.13.1
+- Momentarily limit GIS4WRF installation to QGIS max version 3.2.x due to QGIS bug (#98).
+
 0.13.0
 - Re-style variables list in Geo and View tab (#66, #85).
 - Remove wrfbdy files from list of available files to view (#54).

--- a/gis4wrf/metadata.txt
+++ b/gis4wrf/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=GIS4WRF
-version=0.13.0
+version=0.13.1
 author=D. Meyer and M. Riechert
 email=gis4wrf@mail.com
 description=Toolkit for pre- and post-processing, visualizing, and running simulations in WRF


### PR DESCRIPTION
This is a hot-fix to minimise #98. Momentarily fix the max QGIS version to 3.2.x so to avoid problem on Windows.