### PR TITLE
0.13.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=3 numpy gdal requests pytest
+  - conda create -q -n test-environment python=3.6 numpy gdal requests pytest
   - source activate test-environment
 
 script:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 0.13.2
 - Remove restriction of QGIS max version 3.2.x due to QGIS bug (#98).
 - Update wrf-python wheel URLs for Windows to Python 3.7 (#100).
-- Add workaround Python 3.7.0 bug in subprocess on Windows (#101)
+- Add workaround for Python 3.7.0 bug in subprocess on Windows (#101)
 
 0.13.1
 - Momentarily limit GIS4WRF installation to QGIS max version 3.2.x due to QGIS bug (#98).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 0.13.2
 - Remove restriction of QGIS max version 3.2.x due to QGIS bug (#98).
 - Update wrf-python wheel URLs for Windows to Python 3.7 (#100).
+- Add workaround Python 3.7.0 bug in subprocess on Windows (#101)
 
 0.13.1
 - Momentarily limit GIS4WRF installation to QGIS max version 3.2.x due to QGIS bug (#98).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,6 @@
 0.13.2
 - Remove restriction of QGIS max version 3.2.x due to QGIS bug (#98).
 - Update wrf-python wheel URLs for Windows to Python 3.7 (#100).
-- Add workaround Python 3.7.0 bug in subprocess on Windows (#101)
 
 0.13.1
 - Momentarily limit GIS4WRF installation to QGIS max version 3.2.x due to QGIS bug (#98).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+0.13.2
+- Remove restriction of QGIS max version 3.2.x due to QGIS bug (#98).
+- Update wrf-python wheel URLs for Windows to Python 3.7 (#100).
+
 0.13.1
 - Momentarily limit GIS4WRF installation to QGIS max version 3.2.x due to QGIS bug (#98).
 - Automatically tick MPI checkbox if mpich is detected on the system (#82).

--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -59,30 +59,24 @@ DEPS = [
 # wrf-python does not have official wheels yet, see https://github.com/NCAR/wrf-python/issues/42.
 # Instead, at least for Windows, we install our own.
 # macOS/Linux wheels are built via Travis CI which doesn't provide free artifact storage.
-# NetCDF4 >= 1.3.0 is built against too recent numpy version.
-if PY_MAJORMINOR == ('3', '6'):
-    DEPS += [
-        Dependency('netCDF4',
-            install='1.2.9',
-            min='None'),
-    ]
-    if platform.system() == 'Windows':
+if platform.system() == 'Windows':
+    if PY_MAJORMINOR == ('3', '6'):
         DEPS += [
             Dependency('wrf-python',
-                install='https://ci.appveyor.com/api/buildjobs/sj9br4xl885ncidm/artifacts/wrf_python-1.1.2-cp36-cp36m-win_amd64.whl',
-                min='1.1.2'),
+                       install='https://ci.appveyor.com/api/buildjobs/sj9br4xl885ncidm/artifacts/wrf_python-1.1.2-cp36-cp36m-win_amd64.whl',
+                       min='1.1.2'),
+            Dependency('netCDF4',
+                       install='1.2.9', # >= 1.3.0 is built against too recent numpy version
+                       min='None'),
         ]
-elif PY_MAJORMINOR == ('3', '7'):
-    DEPS += [
-        Dependency('netCDF4',
-            install='1.4.2',
-            min='None'),
-    ]
-    if platform.system() == 'Windows':
+    elif PY_MAJORMINOR == ('3', '7'):
         DEPS += [
             Dependency('wrf-python',
-                install='https://ci.appveyor.com/api/buildjobs/o3ow5itmyi8nhhk2/artifacts/wrf_python-1.1.2-cp37-cp37m-win_amd64.whl',
-                min='1.1.2'),
+                       install='https://ci.appveyor.com/api/buildjobs/o3ow5itmyi8nhhk2/artifacts/wrf_python-1.1.2-cp37-cp37m-win_amd64.whl',
+                       min='1.1.2'),
+            Dependency('netCDF4',
+                       install='1.4.2',
+                       min='None'),
         ]
 
 # Use a custom folder for the packages to avoid polluting the per-user site-packages.

--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -75,7 +75,7 @@ if PY_MAJORMINOR == ('3', '6'):
 elif PY_MAJORMINOR == ('3', '7'):
     DEPS += [
         Dependency('netCDF4',
-            install='1.4.1',
+            install='1.4.2',
             min='None'),
     ]
     if platform.system() == 'Windows':

--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -59,24 +59,30 @@ DEPS = [
 # wrf-python does not have official wheels yet, see https://github.com/NCAR/wrf-python/issues/42.
 # Instead, at least for Windows, we install our own.
 # macOS/Linux wheels are built via Travis CI which doesn't provide free artifact storage.
-if platform.system() == 'Windows':
-    if PY_MAJORMINOR == ('3', '6'):
+# NetCDF4 >= 1.3.0 is built against too recent numpy version.
+if PY_MAJORMINOR == ('3', '6'):
+    DEPS += [
+        Dependency('netCDF4',
+            install='1.2.9',
+            min='None'),
+    ]
+    if platform.system() == 'Windows':
         DEPS += [
             Dependency('wrf-python',
-                       install='https://ci.appveyor.com/api/buildjobs/sj9br4xl885ncidm/artifacts/wrf_python-1.1.2-cp36-cp36m-win_amd64.whl',
-                       min='1.1.2'),
-            Dependency('netCDF4',
-                       install='1.2.9', # >= 1.3.0 is built against too recent numpy version
-                       min='None'),
+                install='https://ci.appveyor.com/api/buildjobs/sj9br4xl885ncidm/artifacts/wrf_python-1.1.2-cp36-cp36m-win_amd64.whl',
+                min='1.1.2'),
         ]
-    elif PY_MAJORMINOR == ('3', '7'):
+elif PY_MAJORMINOR == ('3', '7'):
+    DEPS += [
+        Dependency('netCDF4',
+            install='1.4.2',
+            min='None'),
+    ]
+    if platform.system() == 'Windows':
         DEPS += [
             Dependency('wrf-python',
-                       install='https://ci.appveyor.com/api/buildjobs/o3ow5itmyi8nhhk2/artifacts/wrf_python-1.1.2-cp37-cp37m-win_amd64.whl',
-                       min='1.1.2'),
-            Dependency('netCDF4',
-                       install='1.4.2',
-                       min='None'),
+                install='https://ci.appveyor.com/api/buildjobs/o3ow5itmyi8nhhk2/artifacts/wrf_python-1.1.2-cp37-cp37m-win_amd64.whl',
+                min='1.1.2'),
         ]
 
 # Use a custom folder for the packages to avoid polluting the per-user site-packages.

--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -75,7 +75,7 @@ if PY_MAJORMINOR == ('3', '6'):
 elif PY_MAJORMINOR == ('3', '7'):
     DEPS += [
         Dependency('netCDF4',
-            install='1.4.2',
+            install='1.4.1',
             min='None'),
     ]
     if platform.system() == 'Windows':

--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -42,8 +42,6 @@ DEPS = [
     #Dependency('xarray', install='0.10.0', min=None),
     Dependency('f90nml', install='1.0.2', min=None),
     Dependency('pyyaml', install='3.13', min=None),
-    # >= 1.3.0 is built against too recent numpy version
-    Dependency('netCDF4', install='1.2.9', min=None),
 
     # Indirect dependencies.
     # Indirect dependencies are dependencies that we don't import directly in our code but
@@ -67,12 +65,18 @@ if platform.system() == 'Windows':
             Dependency('wrf-python',
                        install='https://ci.appveyor.com/api/buildjobs/sj9br4xl885ncidm/artifacts/wrf_python-1.1.2-cp36-cp36m-win_amd64.whl',
                        min='1.1.2'),
+            Dependency('netCDF4',
+                       install='1.2.9', # >= 1.3.0 is built against too recent numpy version
+                       min='None'),
         ]
     elif PY_MAJORMINOR == ('3', '7'):
         DEPS += [
             Dependency('wrf-python',
                        install='https://ci.appveyor.com/api/buildjobs/o3ow5itmyi8nhhk2/artifacts/wrf_python-1.1.2-cp37-cp37m-win_amd64.whl',
                        min='1.1.2'),
+            Dependency('netCDF4',
+                       install='1.4.2',
+                       min='None'),
         ]
 
 # Use a custom folder for the packages to avoid polluting the per-user site-packages.

--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -56,27 +56,34 @@ DEPS = [
     # https://github.com/pandas-dev/pandas/issues/18967
     #Dependency('pandas', install='0.20.3', min=None) # for xarray
 ]
-# wrf-python does not have official wheels yet, see https://github.com/NCAR/wrf-python/issues/42.
+# For some packages we need to use different versions depending on the Python version used.
+# Also, wrf-python does not have official wheels yet, see https://github.com/NCAR/wrf-python/issues/42.
 # Instead, at least for Windows, we install our own.
 # macOS/Linux wheels are built via Travis CI which doesn't provide free artifact storage.
-if platform.system() == 'Windows':
-    if PY_MAJORMINOR == ('3', '6'):
+if PY_MAJORMINOR == ('3', '6'):
+    DEPS += [
+        # NetCDF4 >= 1.3.0 is built against too recent numpy version.
+        Dependency('netCDF4',
+            install='1.2.9',
+            min='None'),
+    ]
+    if platform.system() == 'Windows':
         DEPS += [
             Dependency('wrf-python',
-                       install='https://ci.appveyor.com/api/buildjobs/sj9br4xl885ncidm/artifacts/wrf_python-1.1.2-cp36-cp36m-win_amd64.whl',
-                       min='1.1.2'),
-            Dependency('netCDF4',
-                       install='1.2.9', # >= 1.3.0 is built against too recent numpy version
-                       min='None'),
+                install='https://ci.appveyor.com/api/buildjobs/sj9br4xl885ncidm/artifacts/wrf_python-1.1.2-cp36-cp36m-win_amd64.whl',
+                min='1.1.2'),
         ]
-    elif PY_MAJORMINOR == ('3', '7'):
+elif PY_MAJORMINOR == ('3', '7'):
+    DEPS += [
+        Dependency('netCDF4',
+            install='1.4.2',
+            min='None'),
+    ]
+    if platform.system() == 'Windows':
         DEPS += [
             Dependency('wrf-python',
-                       install='https://ci.appveyor.com/api/buildjobs/o3ow5itmyi8nhhk2/artifacts/wrf_python-1.1.2-cp37-cp37m-win_amd64.whl',
-                       min='1.1.2'),
-            Dependency('netCDF4',
-                       install='1.4.2',
-                       min='None'),
+                install='https://ci.appveyor.com/api/buildjobs/o3ow5itmyi8nhhk2/artifacts/wrf_python-1.1.2-cp37-cp37m-win_amd64.whl',
+                min='1.1.2'),
         ]
 
 # Use a custom folder for the packages to avoid polluting the per-user site-packages.
@@ -151,7 +158,7 @@ def bootstrap() -> Iterable[Tuple[str,Any]]:
 
         except pkg_resources.DistributionNotFound as exc:
             needs_install.append(dep)
-    
+
     if needs_install:
         yield ('needs_install', needs_install)
         yield ('log', 'Package directory: ' + INSTALL_PREFIX)

--- a/gis4wrf/metadata.txt
+++ b/gis4wrf/metadata.txt
@@ -16,4 +16,3 @@ tags=WRF, WPS, GIS, NetCDF, GRIB, NWP, weather, atmospheric science, atmospheric
 icon=plugin/resources/gis4wrf_logo.svg
 
 qgisMinimumVersion=3.0
-qgisMaximumVersion=3.2


### PR DESCRIPTION
This PR makes GIS4WRF available for download in QGIS 3.4.x as the bug with pip has been fixed (see https://issues.qgis.org/issues/20249) and QGIS3.4.1 has been made available for download. I have also changed slightly changed the logic for installing package dependencies based on the Python version used and use Python 3.6 in Travis CI.