### PR TITLE
Fix standard longitude for Lambert projection & add Polar Stereographic and Mercator

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,11 @@
+0.14.0
+- Add support for Polar Stereographic and Mercator projections.
+- Allow Standard Longitude to be specified for Lambert conformal projection (#116).
+
 0.13.2
 - Remove restriction of QGIS max version 3.2.x due to QGIS bug (#98).
 - Update wrf-python wheel URLs for Windows to Python 3.7 (#100).
-- Add workaround for Python 3.7.0 bug in subprocess on Windows (#101)
+- Add workaround for Python 3.7.0 bug in subprocess on Windows (#101).
 
 0.13.1
 - Momentarily limit GIS4WRF installation to QGIS max version 3.2.x due to QGIS bug (#98).

--- a/gis4wrf/core/constants.py
+++ b/gis4wrf/core/constants.py
@@ -3,7 +3,16 @@
 
 WRF_EARTH_RADIUS = 6370000
 WRF_PROJ4_SPHERE = '+a={radius} +b={radius}'.format(radius=WRF_EARTH_RADIUS)
-PROJECT_JSON_VERSION = 1
+
+'''
+v1:
+Initial version
+
+v2:
+Add stand_lon to Lambert projections.
+In v1, stand_lon was implicitly required to be identical to domain center longitude.
+'''
+PROJECT_JSON_VERSION = 2
 
 # gdal forces us to provide names for categories starting from index 0.
 # WRF's categories typically start at 1, so we need to add fake entries

--- a/gis4wrf/core/transforms/project_to_wps_namelist.py
+++ b/gis4wrf/core/transforms/project_to_wps_namelist.py
@@ -68,7 +68,7 @@ def convert_project_to_wps_namelist(project: Project) -> dict:
         wps['geogrid']['truelat2'] = innermost_domain['truelat2']
 
     if map_proj in ['lambert', 'polar']:
-        wps['geogrid']['stand_lon'] = innermost_domain['center_lonlat'][0]
+        wps['geogrid']['stand_lon'] = innermost_domain['stand_lon']
 
     if map_proj == 'lat-lon':
         wps['geogrid']['stand_lon'] = innermost_domain['stand_lon'] # rotation

--- a/gis4wrf/core/transforms/wps_namelist_to_project.py
+++ b/gis4wrf/core/transforms/wps_namelist_to_project.py
@@ -47,19 +47,19 @@ def convert_nml_to_project_domains(nml: dict) -> List[dict]:
         raise UnsupportedError('ref_x/ref_y is not supported in namelist')
 
     # Create CRS object from projection metadata.
+    # See wps_binary_to_gdal.py for further explanations regarding latitude
+    # and longitude of origin.
     if map_proj == 'lat-lon':
         if stand_lon != 0.0:
             raise UnsupportedError('Rotated lat-lon projection is not supported')
         crs = CRS.create_lonlat()
     elif map_proj == 'lambert':
-        # It doesn't matter what the latitude origin is.
-        # Longitude is standard longitude and matters.
-        # See wps_binary_to_gdal.py for details.
-        origin = LonLat(lon=stand_lon, lat=(truelat1 + truelat2)/2)
+        arbitrary_latitude_origin = (truelat1 + truelat2)/2
+        origin = LonLat(lon=stand_lon, lat=arbitrary_latitude_origin)
         crs = CRS.create_lambert(truelat1, truelat2, origin)
     elif map_proj == 'mercator':
-        # It doesn't matter what the longitude origin is.
-        crs = CRS.create_mercator(truelat1, 0.0)
+        arbitrary_longitude_origin = 0
+        crs = CRS.create_mercator(truelat1, arbitrary_longitude_origin)
     elif map_proj == 'polar':
         crs = CRS.create_polar(truelat1, stand_lon)
     else:

--- a/gis4wrf/metadata.txt
+++ b/gis4wrf/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=GIS4WRF
-version=0.13.2
+version=0.14.0
 author=D. Meyer and M. Riechert
 email=gis4wrf@mail.com
 description=Toolkit for pre- and post-processing, visualizing, and running simulations in WRF

--- a/gis4wrf/metadata.txt
+++ b/gis4wrf/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=GIS4WRF
-version=0.14.0
+version=0.13.2
 author=D. Meyer and M. Riechert
 email=gis4wrf@mail.com
 description=Toolkit for pre- and post-processing, visualizing, and running simulations in WRF


### PR DESCRIPTION
This fixes #116 and also adds the two missing WRF projections.

**Note:** The gis4wrf [tutorial](https://gis4wrf.github.io/tutorials/) has to be changed as well because standard longitude is now required for Lambert.