### PR TITLE
Fix deps install on Windows using the latest Qgis 3.4 ltr

### DIFF
--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -203,6 +203,8 @@ def bootstrap() -> Iterable[Tuple[str,Any]]:
             else:
                 python_qgis_dir = exe_dir
             python = os.path.abspath(os.path.join(python_qgis_dir, 'python-qgis.bat'))
+            if not os.path.isfile(python):
+                python = os.path.abspath(os.path.join(python_qgis_dir, 'python-qgis-ltr.bat'))
 
         # Must use a single pip install invocation, otherwise dependencies of newly
         # installed packages get re-installed and we couldn't pin versions.


### PR DESCRIPTION
The latest Qgis 3.4 ltr version has 'python-qgis-ltr.bat' instead of 'python-qgis.bat'