### PR TITLE
Fix incorrect filename filter in file open dialogs (fixes #125)

### DIFF
--- a/gis4wrf/plugin/ui/widget_run.py
+++ b/gis4wrf/plugin/ui/widget_run.py
@@ -158,7 +158,7 @@ class RunWidget(QWidget):
         path, _ = QFileDialog.getOpenFileName(
             caption='Open WRF NetCDF File',
             directory=self.project.run_wps_folder,
-            filter='geo_em*;met_em*')
+            filter='WPS output (geo_em* met_em*)')
         if not path:
             return
         self.view_wrf_nc_file.emit(path)
@@ -167,7 +167,7 @@ class RunWidget(QWidget):
         path, _ = QFileDialog.getOpenFileName(
             caption='Open WRF NetCDF File',
             directory=self.project.run_wrf_folder,
-            filter='wrfinput*;wrfout*;wrfrst*')
+            filter='WRF input/output (wrfinput* wrfout* wrfrst*)')
         if not path:
             return
         self.view_wrf_nc_file.emit(path)


### PR DESCRIPTION
For some reason, the filter we used before was incorrect but worked on Windows and macOS, but not on Linux. This PR changes the filter to the [correct format](https://doc-snapshots.qt.io/qt5-5.9/qfiledialog.html#getOpenFileName).