### PR TITLE
Allow GRIB files with different vars in one folder

### DIFF
--- a/gis4wrf/core/readers/grib_metadata.py
+++ b/gis4wrf/core/readers/grib_metadata.py
@@ -46,7 +46,7 @@ def read_grib_files_metadata(paths: List[str]) -> Tuple[GribMetadata, List[GribM
         if not variables:
             variables = meta.variables
         else:
-            assert meta.variables == variables
+            variables.update(meta.variables)
             assert not set(meta.times).intersection(times)
         times.extend(meta.times)
 


### PR DESCRIPTION
This fixes #151. I reproduced/tested it manually by downloading two met datasets with different variables and then copying a file from one into the other dataset folder. 