### PR TITLE
Cleanup metgrid outputs to avoid issue re-running wrf

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+0.14.4 (next release)
+- Fix issue re-running WRF when changing met dataset date/time range (#183).
+
 0.14.3
 - Fix issue opening WPS datasets with special characters in metadata (#167).
 - Fix installation issue on Windows due to inavailability of Python wheels for wrf-python (#176).

--- a/gis4wrf/core/project.py
+++ b/gis4wrf/core/project.py
@@ -423,8 +423,17 @@ class Project(object):
         # TODO create separate functions that clean outputs from previous runs, selectively for geogrid etc.
         if not os.path.exists(wps_folder):
             raise WPSDistributionError(f'{wps_folder} does not exist')
-        self.update_wps_namelist()
+        
         os.makedirs(self.run_wps_folder, exist_ok=True)
+
+        # Remove old metgrid output files, just in case the met dataset time range
+        # has been changed. met_em* files contain date/time in their filenames
+        # and keeping old/unused files may lead to trouble in subsequent steps.
+        # See https://github.com/GIS4WRF/gis4wrf/issues/183.
+        for path in glob.glob(os.path.join(self.run_wps_folder, 'met_em.*.nc')):
+            os.remove(path)
+
+        self.update_wps_namelist()
         # We use the default relative folder locations (./geogrid, ./metgrid)
         # to avoid having to hard-code custom folders in the namelist files.
         geogrid_folder = os.path.join(self.run_wps_folder, 'geogrid')


### PR DESCRIPTION
Fixes #183.

Note that this did not lead to incorrect simulations as `real` picks the right met_em* files anyway. The issue is more with gis4wrf code that tries to read some metadata from the met_em* files to populate the `num_metgrid_levels` option in the namelist for running wrf. If the number is incorrect, real.exe will just exit. Cleaning up old output files before running metgrid fixes this issue and is good style generally.