### PR TITLE
Don't clean wrffdda_*, wrfsfdda_* and wrflowinp_* files before running wrf

### DIFF
--- a/gis4wrf/core/project.py
+++ b/gis4wrf/core/project.py
@@ -471,7 +471,7 @@ class Project(object):
 
         # Remove everything except real.exe output files to ensure
         # that no old files are reused by wrf.exe.
-        clean_exclude = ['wrfinput_', 'wrfbdy_', 'wrfrst_']
+        clean_exclude = ['wrfinput_', 'wrfbdy_', 'wrfrst_', 'wrffdda_', 'wrfsfdda_', 'wrflowinp_']
         for filename in os.listdir(self.run_wrf_folder):
             if any(filename.startswith(exclude) for exclude in clean_exclude):
                 continue


### PR DESCRIPTION
Fixes #164.

In theory, users can override the default filenames with e.g. `gfdda_inname` but this PR should be good enough as people likely won't do that.