### PR TITLE
Fix logging in QGIS 3.20

### DIFF
--- a/gis4wrf/plugin/plugin.py
+++ b/gis4wrf/plugin/plugin.py
@@ -110,7 +110,9 @@ class QGISPlugin():
 
     def init_logging(self) -> None:
         levels = {
-            logging.NOTSET: getattr(Qgis, 'None'),
+            # https://github.com/qgis/QGIS/issues/42996
+            logging.NOTSET: Qgis.NoLevel if hasattr(Qgis, 'NoLevel') else getattr(Qgis, 'None'),
+            
             logging.DEBUG: Qgis.Info,
             logging.INFO: Qgis.Info,
             logging.WARN: Qgis.Warning,


### PR DESCRIPTION
Fixes #213.

This was caused by a backwards-incompatible renaming of a log level in QGIS 3.20, see https://github.com/qgis/QGIS/issues/42996.