### PR TITLE
Fix log level on QGIS 3.16 preventing plugin loading

### DIFF
--- a/gis4wrf/plugin/plugin.py
+++ b/gis4wrf/plugin/plugin.py
@@ -111,7 +111,7 @@ class QGISPlugin():
     def init_logging(self) -> None:
         levels = {
             # https://github.com/qgis/QGIS/issues/42996
-            logging.NOTSET: Qgis.NoLevel if hasattr(Qgis, 'NoLevel') else getattr(Qgis, 'None'),
+            logging.NOTSET: Qgis.NoLevel if hasattr(Qgis, 'NoLevel') else Qgis.Info,
             
             logging.DEBUG: Qgis.Info,
             logging.INFO: Qgis.Info,


### PR DESCRIPTION
Fixes https://github.com/GIS4WRF/gis4wrf/issues/223.

Note: 3.16 worked previously, so this must have been due to some breaking change in a patch version in the 3.16 series. The new code is robust and will work on the old and new behaviour.