### PR TITLE
Fix Ubuntu bootstrap

### DIFF
--- a/gis4wrf/bootstrap.py
+++ b/gis4wrf/bootstrap.py
@@ -125,11 +125,19 @@ def bootstrap() -> Iterable[Tuple[str,Any]]:
         if not path.startswith(INSTALL_PREFIX):
             # On macOS, some global paths are added as well which we don't want.
             continue
+        
+        # Distribution installs of Python in Ubuntu return "dist-packages"
+        # instead of "site-packages". But 'pip install --prefix ..' always
+        # uses "site-packages" as the install location.
+        path = path.replace('dist-packages', 'site-packages')
+
         yield ('log', 'Added {} as module search path'.format(path))
+        
         # Make sure directory exists as it may otherwise be ignored later on when we need it.
         # This is because Python seems to cache whether module search paths do not exist to avoid
         # redundant lookups.
         os.makedirs(path, exist_ok=True)
+
         site.addsitedir(path)
         # pkg_resources doesn't listen to changes on sys.path.
         pkg_resources.working_set.add_entry(path)


### PR DESCRIPTION
The automatic Python package installation technique (bootstrapping) used in GIS4WRF works on Ubuntu 20.04 (and maybe earlier) but then fails at import because the wrong import path is added. The PR fixes that. Once merged, the installation docs can be simplified to be like the Windows ones (just install QGIS).

Related: https://github.com/GIS4WRF/gis4wrf/issues/233

Note that earlier Ubuntu versions had a problem with the bootstrapping method used here (`pip install --prefix ..` wasn't supported) but this seems to have been fixed at some point.